### PR TITLE
canReachThread javítás

### DIFF
--- a/src/logic/GameLogic.java
+++ b/src/logic/GameLogic.java
@@ -435,22 +435,30 @@ public class GameLogic {
                 distance = 2;
                 break;
         }
-        FungusThread temp = insect.getThread().getPrev();
+        FungusThread temp = insect.getThread();
         for (Integer i = 0; i < distance; i++) {
             if (temp == toThread) {
                 return true;
             }
             // ? a Body-hoz értünk meg kell nézni, hogy ér-e el másik threadet a bodyból
-            else if (temp == null) {
+            else if (temp.getPrev() == null) {
                 Integer remainingDistance = distance - i - 1; // Mivel az hogy rálép a Body-ra az is egy lépés,
                 // szóval Body-ból kijövő fonalak közti váltás az nem 1 hanem 2 lépés
                 // 0: nem csinál semmit,
                 // 1: body-ból kinövő threadeket nézi,
                 // 2: 1-es és a threadek szomszédai
-                if (canReachFromBody(toThread, temp, remainingDistance))
+                
+                //Olyan thread-et vizsgálunk, amelynek megszakadt a kapcsolata a body-jával, 
+                //tehát a getBody az null. Ez akkor történhet mikor egy fonal véghez értünk.
+                //Normál esetben ez azt jelenti, hogy Body-hoz értünk, de ha a fonal FeedThreadTektonon van
+                //az életben tartja, úgy hogy nincs kapcsolata semmilyen testel. 
+                //!A Body csak is kizárólag ebben az esetben lehet null. Máskor sosem. 
+                if (temp.getBody() != null) {
+                    if (canReachFromBody(toThread, temp, remainingDistance))
                     return true;
+                }//Nem csinálunk semmit, ha a body null. Akadályba ütköztünk, ezen úton nem érjük el a keresett fonalat
                 break;
-            }
+            } 
             temp = temp.getPrev();
         }
 
@@ -461,8 +469,14 @@ public class GameLogic {
             } else if (temp == null) {
                 break;
             }
+            //Ha a getNext() null, akkor fixen egy olyan fonalon vagyunk jelenleg, amiből még gombatest nőtt
             if (temp.getNext() == null) {
-                if (toThread.getBody() == temp.getBody()) {
+                //Van az az eset, ha szegény rovarunk olyan fonalakon mozog, amelyeknek megszünt a kapcsolata a gombatestjével
+                //Nos ilyenkor a cél fonal Body-ja null. Ilyenkor nem tudjuk, megnézni, hogy a cél fonal body-jaból elérhető-e a 
+                //keresett fonal, hiszen a test az null.
+                //Ha tempnek és a toThreadnek megegyezik a Body-ja(és ez nem null), csak akkor nézhetjük meg, hogy elérhető-e
+                //adott body-ból a keresett fonalunk
+                if (toThread.getBody() == temp.getBody() && temp.getBody() != null) {
                     if (canReachFromBody(toThread, temp, distance - i - 1))
                         return true;
                 }


### PR DESCRIPTION
Kijavítottam, hogy képes legyen olyan fonalakra is ellenőrizni, amelyeknek megszünt a kapcsolata a saját tektonjával(FeedThreadTekton).
Emellett kommenteztem a lényeges részeket, hogy mit miért gondolok úgy és valósítottam meg.

Emellett megjelent bennem egy issue, hogy az elvágott fonalak, amelyeknek megszűnik a kapcsolata a Body-ukkal, a kódon belül megvan ez valósítva? Hogy végig megy az "leszakadt" fonal láncon és átállítja a body-kat null-ra?  

Edit: Megnéztem. Nincs ilyen.