### PR TITLE
Growbody bug

### DIFF
--- a/data/tests/growbody_Succes.txt
+++ b/data/tests/growbody_Succes.txt
@@ -9,7 +9,6 @@
 /set s3 tekton t1
 /set t1 addspore s3
 /create thread th1
-/set th1 species fs1
 /set th1 addtekton t1
 /set t1 addthread th1
 /create fungusspecies fs1

--- a/src/model/fungus/FungusSpecies.java
+++ b/src/model/fungus/FungusSpecies.java
@@ -291,7 +291,7 @@ public class FungusSpecies implements iControl {
             FungusBody fb = new FungusBody(null, null);
             thread.getTekton(null).setBody(fb);
             for (Integer i = 0; i < atleast; i++) {
-                thread.getTekton().getSpores().get(i).absorbed();
+                thread.getTekton().getSpores().get(0).absorbed();
             }
             fb.setTekton(thread.getTekton(null));
             fb.addThread(thread);


### PR DESCRIPTION
A spóratörlés indexelésével volt probléma. Mindig az i.-k spórára hívtuk az absorbed függvényt pedig a 0.kra kellett volna.